### PR TITLE
Added GB and TB support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,160 @@
+# Byte-compiled / optimized / DLL files
+__pycache__/
+*.py[cod]
+*$py.class
+
+# C extensions
+*.so
+
+# Distribution / packaging
+.Python
+build/
+develop-eggs/
+dist/
+downloads/
+eggs/
+.eggs/
+lib/
+lib64/
+parts/
+sdist/
+var/
+wheels/
+share/python-wheels/
+*.egg-info/
+.installed.cfg
+*.egg
+MANIFEST
+
+# PyInstaller
+#  Usually these files are written by a python script from a template
+#  before PyInstaller builds the exe, so as to inject date/other infos into it.
+*.manifest
+*.spec
+
+# Installer logs
+pip-log.txt
+pip-delete-this-directory.txt
+
+# Unit test / coverage reports
+htmlcov/
+.tox/
+.nox/
+.coverage
+.coverage.*
+.cache
+nosetests.xml
+coverage.xml
+*.cover
+*.py,cover
+.hypothesis/
+.pytest_cache/
+cover/
+
+# Translations
+*.mo
+*.pot
+
+# Django stuff:
+*.log
+local_settings.py
+db.sqlite3
+db.sqlite3-journal
+
+# Flask stuff:
+instance/
+.webassets-cache
+
+# Scrapy stuff:
+.scrapy
+
+# Sphinx documentation
+docs/_build/
+
+# PyBuilder
+.pybuilder/
+target/
+
+# Jupyter Notebook
+.ipynb_checkpoints
+
+# IPython
+profile_default/
+ipython_config.py
+
+# pyenv
+#   For a library or package, you might want to ignore these files since the code is
+#   intended to run in multiple environments; otherwise, check them in:
+# .python-version
+
+# pipenv
+#   According to pypa/pipenv#598, it is recommended to include Pipfile.lock in version control.
+#   However, in case of collaboration, if having platform-specific dependencies or dependencies
+#   having no cross-platform support, pipenv may install dependencies that don't work, or not
+#   install all needed dependencies.
+#Pipfile.lock
+
+# poetry
+#   Similar to Pipfile.lock, it is generally recommended to include poetry.lock in version control.
+#   This is especially recommended for binary packages to ensure reproducibility, and is more
+#   commonly ignored for libraries.
+#   https://python-poetry.org/docs/basic-usage/#commit-your-poetrylock-file-to-version-control
+#poetry.lock
+
+# pdm
+#   Similar to Pipfile.lock, it is generally recommended to include pdm.lock in version control.
+#pdm.lock
+#   pdm stores project-wide configurations in .pdm.toml, but it is recommended to not include it
+#   in version control.
+#   https://pdm.fming.dev/#use-with-ide
+.pdm.toml
+
+# PEP 582; used by e.g. github.com/David-OConnor/pyflow and github.com/pdm-project/pdm
+__pypackages__/
+
+# Celery stuff
+celerybeat-schedule
+celerybeat.pid
+
+# SageMath parsed files
+*.sage.py
+
+# Environments
+.env
+.venv
+env/
+venv/
+ENV/
+env.bak/
+venv.bak/
+
+# Spyder project settings
+.spyderproject
+.spyproject
+
+# Rope project settings
+.ropeproject
+
+# mkdocs documentation
+/site
+
+# mypy
+.mypy_cache/
+.dmypy.json
+dmypy.json
+
+# Pyre type checker
+.pyre/
+
+# pytype static type analyzer
+.pytype/
+
+# Cython debug symbols
+cython_debug/
+
+# PyCharm
+#  JetBrains specific template is maintained in a separate JetBrains.gitignore that can
+#  be found at https://github.com/github/gitignore/blob/main/Global/JetBrains.gitignore
+#  and can be added to the global gitignore or merged into this file.  For a more nuclear
+#  option (not recommended) you can uncomment the following to ignore the entire idea folder.
+.idea/

--- a/README.md
+++ b/README.md
@@ -1,11 +1,19 @@
 # IMAGENT watcher
 #### Work in Progress
 
-Apparently the system process `imagent` is broken in Mac OS Sierra. 
-It consumes more memory than it should making your computer incredibly **SLOW** (up to `4GB` and it keeps going unless you stop it).
+The system process `imagent` appears to be broken at least in macOS Sierra or higher. 
+It consumes more memory than it should making your computer incredibly **SLOW**
+(up to `4GB` and it keeps going unless you stop it).
 In Mac OS Mojave it consumes up to `30MB` which is alright. 
 
-This script will watch and kill the process if it reaches the specified threshold (`60MB` by default)
+This script will watch and kill the process if it reaches the specified threshold (`100MB` by default)
 
-The easiest solution would be upgrading to the latest OS. However I know that some people can't do this
-because some stuff is still not supported in Mojave. So if you are one of us I hope this helps you 👍
+~~The easiest solution would be upgrading to the latest OS.~~
+There are occasions when, in macOS Monterey, `imagent` would accumulate memory footprints as large as 25GB+
+(Yes, a.k.a. 25,000MB+, I'm not kidding).
+~~However I know that some people can't do this because some stuff is still not supported in Mojave.~~
+So if you are one of us I hope this woulf help you. 👍
+
+## Pre-requisite
+1. python 3.10+
+2. `pip3 install psutil`

--- a/watcher.py
+++ b/watcher.py
@@ -6,17 +6,17 @@ import psutil
 
 
 class Unit(Enum):
-  KB = "K"
-  MB = "M"
-  GB = "G"
-  TB = "T"
+    KB = "K"
+    MB = "M"
+    GB = "G"
+    TB = "T"
 
 
 class Multiplier(Enum):
-  KB = 1
-  MB = 1000 * KB
-  GB = 1000 * MB
-  TB = 1000 * GB
+    KB = 1
+    MB = 1000 * KB
+    GB = 1000 * MB
+    TB = 1000 * GB
 
 
 # You can watch any process in my case it was the imagent because it had a memory leak in Mac OS Sierra
@@ -27,22 +27,25 @@ THRESHOLD = 100 * Multiplier[UNIT.name].value  # Normalize size unit to KB
 # Process list command, this will print "$memory_usage $PID $proces_name"
 COMMAND = "top -o mem -l 1 | grep imagent | awk '{print $8 \" \" $1 \" \" $2}'"
 
-def killProcess(pid):
-  process = psutil.Process(pid)
-  if process.name() == PROCESS:
-    process.kill()
-    print("Killed. pid={} pname={}".format(pid, process.name()))
-  return True
+
+def kill_process(pid_):
+    process = psutil.Process(pid_)
+    if process.name() == PROCESS:
+        process.kill()
+        print("Killed. pid={} pname={}".format(pid_, process.name()))
+    return True
+
 
 # This runs until no more matches are found
-def runUntilKilled(pid):
-  res = killProcess(pid)
-  if not res:
-    print("No process to kill")
-    return
+def run_until_killed(pid_):
+    res = kill_process(pid_)
+    if not res:
+        print("No process to kill")
+        return
+
 
 # Execute process list command
-output = subprocess.check_output(['bash','-c', COMMAND])
+output = subprocess.check_output(['bash', '-c', COMMAND])
 output = str(output).split(' ')
 
 # subprocess.check_output(['bash','-c', 'open .'])
@@ -62,12 +65,12 @@ unit = Unit(unit)
 mem = re.findall(mem_regex, memory)
 mem = int(''.join(str(e) for e in mem))
 match unit:  # Normalize size unit to KB
-  case UNIT.MB:
-    mem *= Multiplier.MB.value
-  case UNIT.GB:
-    mem *= Multiplier.GB.value
-  case UNIT.TB:
-    mem *= Multiplier.TB.value
+    case UNIT.MB:
+        mem *= Multiplier.MB.value
+    case UNIT.GB:
+        mem *= Multiplier.GB.value
+    case UNIT.TB:
+        mem *= Multiplier.TB.value
 
 # PID
 pid = int(''.join(re.findall(mem_regex, pid)))
@@ -76,11 +79,11 @@ pid = int(''.join(re.findall(mem_regex, pid)))
 print("==========RUNNING=============")
 # If an undesired process is found, we get rid of it
 if mem >= THRESHOLD:
-  print("Found memory-leaking process! Killing process \"{}\" (pid={} mem={}{}>{}{}).".format(
-    pname, pid,
-    mem/Multiplier[unit.name].value, unit.name,
-    THRESHOLD/Multiplier[UNIT.name].value, UNIT.name
-  ))
-  runUntilKilled(pid)
+    print("Found memory-leaking process! Killing process \"{}\" (pid={} mem={}{}>{}{}).".format(
+        pname, pid,
+        mem / Multiplier[unit.name].value, unit.name,
+        THRESHOLD / Multiplier[UNIT.name].value, UNIT.name
+    ))
+    run_until_killed(pid)
 else:
-  print("No memory-leaking processes found.")
+    print("No memory-leaking processes found.")

--- a/watcher.py
+++ b/watcher.py
@@ -1,49 +1,45 @@
-import subprocess
 import re
+import subprocess
+from enum import Enum
+
 import psutil
+
+
+class Unit(Enum):
+  KB = "K"
+  MB = "M"
+  GB = "G"
+  TB = "T"
+
+
+class Multiplier(Enum):
+  KB = 1
+  MB = 1000 * KB
+  GB = 1000 * MB
+  TB = 1000 * GB
+
 
 # You can watch any process in my case it was the imagent because it had a memory leak in Mac OS Sierra
 PROCESS = "imagent"
-THRESHOLD = 100 # MB
-THRESHOLD = 2000
-UNIT = "M"
-UNIT = "K"
+UNIT = Unit.MB
+THRESHOLD = 100 * Multiplier[UNIT.name].value  # Normalize size unit to KB
 
-# Process list command, this will print the memory usage and the PID
-COMMAND = "top -o mem -l 1 | grep imagent | awk '{print $8 \" \" $1}'"
+# Process list command, this will print "$memory_usage $PID $proces_name"
+COMMAND = "top -o mem -l 1 | grep imagent | awk '{print $8 \" \" $1 \" \" $2}'"
 
 def killProcess(pid):
-  # Iterate over all running process
-  for proc in psutil.process_iter():
-    try:
-      # Get process name & pid from process object.
-      processName = proc.name()
-      processPID = str(proc.pid)
-
-      # If a match is found, then kill the process
-      if (processName == PROCESS) or (processPID == pid):
-        print("Trying to kill...")
-        proc.kill()
-        print("Killed ", processName, " with PID ", processPID)
-        return True
-    except (psutil.NoSuchProcess, psutil.AccessDenied, psutil.ZombieProcess) as error:
-      print("Error: ", error)
-      return False
-
-  return False
+  process = psutil.Process(pid)
+  if process.name() == PROCESS:
+    process.kill()
+    print("Killed. pid={} pname={}".format(pid, process.name()))
+  return True
 
 # This runs until no more matches are found
 def runUntilKilled(pid):
   res = killProcess(pid)
   if not res:
     print("No process to kill")
-    return 
-
-  # Loop the processes and kill matches
-  while res:
-    res = killProcess(pid)
-
-  print("Process killed.")
+    return
 
 # Execute process list command
 output = subprocess.check_output(['bash','-c', COMMAND])
@@ -53,25 +49,38 @@ output = str(output).split(' ')
 
 memory = output[0]
 pid = output[1]
+pname = re.findall("(.*)\\\\n", output[2])[0]
 
 mem_regex = "(\d)"
-unit_regex = "([KMB])"
+unit_regex = "([KMGTB])"
+
+# Unit T, G, M, K, B (Megabytes, kilobytes, bytes)
+unit = re.findall(unit_regex, memory)[0]
+unit = Unit(unit)
 
 # Memory info
 mem = re.findall(mem_regex, memory)
 mem = int(''.join(str(e) for e in mem))
-
-# Unit M, K, B (Megabytes, kilobytes, bytes)
-unit = re.findall(unit_regex, memory)[0]
+match unit:  # Normalize size unit to KB
+  case UNIT.MB:
+    mem *= Multiplier.MB.value
+  case UNIT.GB:
+    mem *= Multiplier.GB.value
+  case UNIT.TB:
+    mem *= Multiplier.TB.value
 
 # PID
-pid = ''.join(re.findall(mem_regex, pid))
+pid = int(''.join(re.findall(mem_regex, pid)))
 
 # print(mem, unit, pid)
 print("==========RUNNING=============")
 # If an undesired process is found, we get rid of it
-if unit == UNIT and mem >= THRESHOLD:
-  print("Found mem. leak process! Killing " + pid)
+if mem >= THRESHOLD:
+  print("Found memory-leaking process! Killing process \"{}\" (pid={} mem={}{}>{}{}).".format(
+    pname, pid,
+    mem/Multiplier[unit.name].value, unit.name,
+    THRESHOLD/Multiplier[UNIT.name].value, UNIT.name
+  ))
   runUntilKilled(pid)
 else:
-  print("No mem. leak processes found")
+  print("No memory-leaking processes found.")


### PR DESCRIPTION
Before, the `watcher.py` script only seemed to support up to MB.
It didn't recognize `'G'` in `$8` of what `top -o mem -l 1` produces.

Hope this has made imagent_watcher better ;)